### PR TITLE
Ewald split

### DIFF
--- a/fix_conp.cpp
+++ b/fix_conp.cpp
@@ -163,6 +163,9 @@ FixConp::FixConp(LAMMPS *lmp, int narg, char **arg) :
     else if (strcmp(arg[iarg],"pppm") == 0) {
       pppmflag = true;
     }
+    else if (strcmp(arg[iarg],"split") == 0) {
+      splitflag = true;
+    }
     else {
       printf(".<%s>.\n",arg[iarg]);
       error->all(FLERR,"Invalid fix conp input command");

--- a/fix_conp.h
+++ b/fix_conp.h
@@ -76,6 +76,7 @@ class FixConp : public Fix {
   class KSpaceModule *kspmod;
   double eta;
   int *elenum_list,*displs,*eleall2ele;
+  bool splitflag;
 
  protected:
   class NeighList *list;

--- a/km_ewald_split.h
+++ b/km_ewald_split.h
@@ -58,9 +58,9 @@ class KSpaceModuleEwaldSplit : public KSpaceModule, public Pointers {
   void make_kxy_list_from_kvecs();
   void sincos_a_transpose(double **, double **);
   void kz_expand(double*, double*, double*, double*, double*);
-  double ewald_dot_ij(double*, double*, double*, double*,
-                    double*, double*, double*, double*); 
+  double ewald_dot_ij(double*, double*, double*, double*, double*, double*, double*, double*); 
   double ewald_dot_ii(double*, double*, double*, double*);
+  double ewald_dot_ib(int, double*, double*, double*);
   double unitk[3];
   double *ug;
   double g_ewald,gsqmx,volume,slab_volfactor;

--- a/km_ewald_split.h
+++ b/km_ewald_split.h
@@ -56,7 +56,11 @@ class KSpaceModuleEwaldSplit : public KSpaceModule, public Pointers {
   void make_kvecs_brick();
   void make_ug_from_kvecs();
   void make_kxy_list_from_kvecs();
-  
+  void sincos_a_transpose(double **, double **);
+  void kz_expand(double*, double*, double*, double*, double*);
+  double ewald_dot_ij(double*, double*, double*, double*,
+                    double*, double*, double*, double*); 
+  double ewald_dot_ii(double*, double*, double*, double*);
   double unitk[3];
   double *ug;
   double g_ewald,gsqmx,volume,slab_volfactor;

--- a/pppm_conp.cpp
+++ b/pppm_conp.cpp
@@ -18,6 +18,7 @@
 
 #include "pppm_conp.h"
 #include "km_ewald.h"
+#include "km_ewald_split.h"
 
 #include "gridcomm.h"
 #include "fft3d_wrap.h"
@@ -89,7 +90,8 @@ void PPPMCONP::conp_post_neighbor(
 
 void PPPMCONP::a_cal(double * aaa)
 {
-  my_ewald = new KSpaceModuleEwald(lmp);
+  if (fixconp->splitflag) my_ewald = new KSpaceModuleEwaldSplit(lmp);
+  else my_ewald = new KSpaceModuleEwald(lmp);
   my_ewald->register_fix(fixconp);
   my_ewald->conp_setup();
   my_ewald->conp_post_neighbor(false,true); // ele_allocate

--- a/pppm_conp.h
+++ b/pppm_conp.h
@@ -54,7 +54,7 @@ class PPPMCONP : public PPPM, public KSpaceModule {
   void ele_deallocate();
   void elyte_deallocate();
 
-  class KSpaceModuleEwald* my_ewald;
+  class KSpaceModule* my_ewald;
   bool first_postneighbor;
   bool first_bcal;
   bool reuseflag;

--- a/pppm_conp_intel.cpp
+++ b/pppm_conp_intel.cpp
@@ -18,6 +18,7 @@
 
 #include "pppm_conp_intel.h"
 #include "km_ewald.h"
+#include "km_ewald_split.h"
 
 #include "atom.h"
 #include "comm.h"
@@ -110,7 +111,8 @@ void PPPMCONPIntel::fill_j2i()
 
 void PPPMCONPIntel::a_cal(double * aaa)
 {
-  my_ewald = new KSpaceModuleEwald(lmp);
+  if (fixconp->splitflag) my_ewald = new KSpaceModuleEwaldSplit(lmp);
+  else my_ewald = new KSpaceModuleEwald(lmp);
   my_ewald->register_fix(fixconp);
   my_ewald->conp_setup();
   my_ewald->conp_post_neighbor(false,true); // ele_allocate

--- a/pppm_conp_intel.h
+++ b/pppm_conp_intel.h
@@ -44,7 +44,7 @@ class PPPMCONPIntel : public PPPMIntel, public KSpaceModule {
   void conp_pre_force() {elyte_mapped = false;particles_mapped = false;}
   void update_charge();
  protected:
-  class KSpaceModuleEwald * my_ewald;
+  class KSpaceModule * my_ewald;
   template<class flt_t, class acc_t, int use_table>
   void aaa_map_rho(IntelBuffers<flt_t,acc_t> *buffers);
   template<class flt_t, class acc_t>


### PR DESCRIPTION
fixed up km_ewald_split so that especially large systems can be run with a smaller memory footprint.