### PR TITLE
Updated installation process to hook in to LAMMPS' CMake process.

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -41,7 +41,6 @@ action compute_potential_atom.cpp pppm.h
 action compute_potential_atom.h pppm.h
 action pppm_conp.cpp pppm.h
 action pppm_conp.h pppm.h
-action pppm_conp_intel.cpp pppm_intel.cpp
-action pppm_conp_intel.h pppm_intel.h
 action fix_conp.cpp
 action fix_conp.h
+action incl_pppm_intel_templates.cpp

--- a/README.md
+++ b/README.md
@@ -12,9 +12,34 @@ The USER-CONP2 package allows users to perform LAMMPS MD simulations with consta
 
 This is version 1.0 of the code. Upgrade priorities for version 1.1 are listed throughout this document in **boldface**; I welcome all feature suggestions!
 
+# Dependencies
+This package is only guaranteed to work for the 27May2021 patch of LAMMPS. Although it *may* work with
+other versions, they are not officially supported by the USER-CONP2 developers and may require extra
+work on the part of the user to compile.
+
+The fix requires BLAS and LAPACK compatible linear algebra libraries, although it's not fussy about
+which ones to use. CMake will automatically attempt to find compatible libraries during the
+configuration stage and will build its own if it can't find any, although this will be slower than using
+libraries optimised for the target machine. CMake is usually accurate when
+finding libraries, but it may be necessary to modify the `CMAKE_CXX_FLAGS` variable to explicitly
+specify the desired library location and link flags.
+
 # Installation instructions
 
-Currently the easiest way to install USER-CONP2 is to copy all relevant .cpp/.h files into the LAMMPS src folder, and compile. Note that ``pppm_conp_intel.cpp/h`` require the USER-INTEL package to be compiled at the same time. **Work is in progress to wrap this all up into a ``USER-CONP2''-style folder together with CMake patches to streamline the process.**
+Installation is managed via the `install_cmake.sh` script in the root directory. This script copies the
+necessary files into a dedicated `USER-CONP2` folder in the LAMMPS `src` directory and integrates with
+LAMMPS' CMake build process. The installation steps are as follows:
+
+1. Set the `LAMMPS_PREFIX` environment variable to the location of the base LAMMPS directory (note: this
+   must be the *root* directory containing the `README` file, not the `src` directory). In bash, run the
+   command `export LAMMPS_PREFIX=/path/to/lammps`.
+2. In the root directory of *this* repository, run the install script via `bash ./install_cmake.sh`
+3. Compile LAMMPS using the usual CMake procedure, setting `-D PKG_USER-CONP2=on`. The fix can be used
+   with the `USER-INTEL` accelerator package by also setting `-D PKG_USER-INTEL=on`, in which case you
+   should use the Intel C++ compiler and link against Intel MKL for the best performance.
+
+It is also possible to use the legacy `make`-based build system by copying all relevant `.cpp` and `.h`
+files into the LAMMPS `src` directory and manually specifying the BLAS/LAPACK compile and link options.
 
 # Usage instructions
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ libraries optimised for the target machine. CMake is usually accurate when
 finding libraries, but it may be necessary to modify the `CMAKE_CXX_FLAGS` variable to explicitly
 specify the desired library location and link flags.
 
+Git is required by the `install_cmake.sh` installation script.
+
 # Installation instructions
 
 Installation is managed via the `install_cmake.sh` script in the root directory. This script copies the

--- a/incl_pppm_intel_templates.cpp
+++ b/incl_pppm_intel_templates.cpp
@@ -1,4 +1,5 @@
 // File "pppm_impl.cpp"
+#ifdef LMP_USER_INTEL
 #include "pppm_intel.cpp"
 
 using namespace LAMMPS_NS;
@@ -12,3 +13,4 @@ template void PPPMIntel::make_rho<float,float,0>(IntelBuffers<float,float> *buff
 template void PPPMIntel::make_rho<float,double,1>(IntelBuffers<float,double> *buffers); 
 template void PPPMIntel::make_rho<double,double,1>(IntelBuffers<double,double> *buffers);
 template void PPPMIntel::make_rho<float,float,1>(IntelBuffers<float,float> *buffers);
+#endif

--- a/install_cmake.sh
+++ b/install_cmake.sh
@@ -22,6 +22,7 @@ fi
 echo "Copying base CONP files..."
 cp -v compute_potential_atom.* fix_conp.* fix_conp_dyn2.* fix_conp_dyn.* \
 km_ewald.* km_ewald_split.* kspacemodule.h pppm_conp.* incl_pppm_intel_templates.cpp \
+Install.sh \
 ${CONP_SRC_DIR} || exit 1
 echo "Done"
 # And the Intel accelerated styles

--- a/install_cmake.sh
+++ b/install_cmake.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script really shouldn't be run in a pipe
+set -o pipefail
+
+# First, check that the user has specified where to install the files
+if [[ -z "${LAMMPS_PREFIX}" ]]; then
+  echo "Error: LAMMPS install directory not found. Set LAMMPS_PREFIX environment variable and retry."
+  exit 1
+else
+  CONP_DOWNLOAD_DIR=$(pwd -P)
+  CONP_SRC_DIR="${LAMMPS_PREFIX}"/src/USER-CONP2
+  INTEL_DIR="${LAMMPS_PREFIX}"/src/USER-INTEL
+
+  echo "Creating CONP source directory..."
+  mkdir "${CONP_SRC_DIR}"
+  echo "Done"
+fi
+
+# Copy the source files to the source directory
+# Do the base files first
+echo "Copying base CONP files..."
+cp -v compute_potential_atom.* fix_conp.* fix_conp_dyn2.* fix_conp_dyn.* \
+km_ewald.* km_ewald_split.* kspacemodule.h pppm_conp.* incl_pppm_intel_templates.cpp \
+${CONP_SRC_DIR} || exit 1
+echo "Done"
+# And the Intel accelerated styles
+echo "Copying Intel-accelerated CONP files..."
+cp -v pppm_conp_intel.* ${INTEL_DIR} || exit 1
+echo "Done"
+
+# Now we need to patch the LAMMPS CMakeLists.txt to detect and build the CONP2 files
+echo "Moving to ${LAMMPS_PREFIX} and patching CMakeLists.txt..."
+cd ${LAMMPS_PREFIX}
+git apply ${CONP_DOWNLOAD_DIR}/patchfile || exit 1
+echo "Done"
+cd ${CONP_DOWNLOAD_DIR}
+echo "================="
+echo "Finished copying USER-CONP2 files." 
+echo "You can now build LAMMPS with CMake by setting -D PKG_USER-CONP2=on"

--- a/patchfile
+++ b/patchfile
@@ -1,5 +1,5 @@
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index aa6b0ed583..67775c4c03 100644
+index aa6b0ed583..12d8eec863 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
 @@ -146,7 +146,7 @@ set(STANDARD_PACKAGES ASPHERE BODY CLASS2 COLLOID COMPRESS DIPOLE
@@ -24,7 +24,7 @@ index aa6b0ed583..67775c4c03 100644
  endif()
  
 -if(PKG_MSCG OR PKG_USER-ATC OR PKG_USER-AWPMD OR PKG_USER-QUIP OR PKG_LATTE)
-+if(PKG_MSCG OR PKG_USER-ATC OR PKG_USER-AWPMD OR PKG_USER-QUIP OR PKG_LATTE OR USER-CONP2)
++if(PKG_MSCG OR PKG_USER-ATC OR PKG_USER-AWPMD OR PKG_USER-QUIP OR PKG_LATTE OR PKG_USER-CONP2)
    enable_language(C)
    find_package(LAPACK)
    find_package(BLAS)
@@ -39,3 +39,41 @@ index aa6b0ed583..67775c4c03 100644
  ######################################################################
  # packages which selectively include variants based on enabled styles
  # e.g. accelerator packages
+diff --git a/src/Depend.sh b/src/Depend.sh
+index f77d435fc5..aeda21f96c 100755
+--- a/src/Depend.sh
++++ b/src/Depend.sh
+@@ -149,3 +149,7 @@ if (test $1 = "USER-REAXC") then
+   depend KOKKOS
+   depend USER-OMP
+ fi
++
++if (test $1 = "USER-CONP2") then
++  depend USER-INTEL
++fi
+diff --git a/src/Makefile b/src/Makefile
+index 24d99a5fe3..a62fa3e4dc 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -58,7 +58,7 @@ PACKUSER = user-adios user-atc user-awpmd user-brownian user-bocs user-cgdna \
+ 	   user-mofff user-molfile user-netcdf user-omp user-phonon \
+ 	   user-pace user-plumed user-ptm user-qmmm user-qtb user-quip \
+ 	   user-rann user-reaction user-reaxc user-scafacos user-smd user-smtbq \
+-	   user-sdpd user-sph user-tally user-uef user-vtk user-yaff
++	   user-sdpd user-sph user-tally user-uef user-vtk user-yaff user-conp2
+ 
+ PACKLIB = compress gpu kim kokkos latte message mpiio mscg poems python voronoi \
+ 	  user-adios user-atc user-awpmd user-colvars user-h5md user-hdnnp user-lb user-mdi \
+diff --git a/src/USER-INTEL/intel_buffers.h b/src/USER-INTEL/intel_buffers.h
+index 607cc2fd82..11aeb29c72 100644
+--- a/src/USER-INTEL/intel_buffers.h
++++ b/src/USER-INTEL/intel_buffers.h
+@@ -201,7 +201,7 @@ class IntelBuffers {
+   #endif
+ 
+   inline void thr_pack(const int ifrom, const int ito, const int ago) {
+-    if (ago == 0) {
++    if (true) {
+       #if defined(LMP_SIMD_COMPILER)
+       #pragma vector aligned
+       #pragma ivdep

--- a/patchfile
+++ b/patchfile
@@ -1,0 +1,41 @@
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index aa6b0ed583..67775c4c03 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -146,7 +146,7 @@ set(STANDARD_PACKAGES ASPHERE BODY CLASS2 COLLOID COMPRESS DIPOLE
+   USER-HDNNP USER-LB USER-MANIFOLD USER-MDI USER-MEAMC USER-MESONT USER-MGPT USER-MISC
+   USER-MOFFF USER-MOLFILE USER-NETCDF USER-PHONON USER-PLUMED USER-PTM USER-QTB
+   USER-RANN USER-REACTION USER-REAXC USER-SCAFACOS USER-SDPD USER-SMD USER-SMTBQ USER-SPH
+-  USER-TALLY USER-UEF USER-VTK USER-QUIP USER-QMMM USER-YAFF USER-PACE USER-BROWNIAN)
++  USER-TALLY USER-UEF USER-VTK USER-QUIP USER-QMMM USER-YAFF USER-PACE USER-BROWNIAN USER-CONP2)
+ 
+ set(SUFFIX_PACKAGES CORESHELL GPU KOKKOS OPT USER-INTEL USER-OMP)
+ 
+@@ -235,6 +235,7 @@ pkg_depends(USER-ATC MANYBODY)
+ pkg_depends(USER-LB MPI)
+ pkg_depends(USER-PHONON KSPACE)
+ pkg_depends(USER-SCAFACOS MPI)
++pkg_depends(USER-CONP2 KSPACE)
+ 
+ # detect if we may enable OpenMP support by default
+ set(BUILD_OMP_DEFAULT OFF)
+@@ -269,7 +270,7 @@ if(BUILD_OMP)
+   target_link_libraries(lammps PRIVATE OpenMP::OpenMP_CXX)
+ endif()
+ 
+-if(PKG_MSCG OR PKG_USER-ATC OR PKG_USER-AWPMD OR PKG_USER-QUIP OR PKG_LATTE)
++if(PKG_MSCG OR PKG_USER-ATC OR PKG_USER-AWPMD OR PKG_USER-QUIP OR PKG_LATTE OR USER-CONP2)
+   enable_language(C)
+   find_package(LAPACK)
+   find_package(BLAS)
+@@ -490,6 +491,10 @@ if(PKG_USER-H5MD)
+   include(Packages/USER-H5MD)
+ endif()
+ 
++if(PKG_USER-CONP2)
++    target_link_libraries(lammps PRIVATE ${LAPACK_LIBRARIES})
++endif()
++
+ ######################################################################
+ # packages which selectively include variants based on enabled styles
+ # e.g. accelerator packages


### PR DESCRIPTION
This commit adds a shell-script to copy the USER-CONP2 source files and patch
LAMMPS' CMakeLists.txt to automatically build and link the CONP2 module,
including functionality to automatically find and/or build BLAS and LAPACK libs.